### PR TITLE
Bump GitHub Actions dependencies (combine PRs #48-51)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
         msbuild ${{ env.SOLUTION_FILE_PATH }} /p:Configuration=${{ env.BUILD_CONFIGURATION }} /p:Platform=${{ env.BUILD_PLATFORM }} /p:PlatformToolset=v143 /p:WindowsTargetPlatformVersion=10.0 /p:LangVersion=preview /m
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: TCMT-Windows-Client-${{ env.BUILD_PLATFORM }}-${{ env.BUILD_CONFIGURATION }}
         path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       run: dir "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA"
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@v3
 
     # .NET tools 缓存
     - name: Cache .NET tools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         key: cuda-12.6.0
 
     - name: Setup CUDA 12.6
-      uses: Jimver/cuda-toolkit@v0.2.29
+      uses: Jimver/cuda-toolkit@v0.2.35
       with:
         cuda: '12.6.0'
         method: 'network'

--- a/.github/workflows/sync-to-gitee-gitlab.yml
+++ b/.github/workflows/sync-to-gitee-gitlab.yml
@@ -36,4 +36,4 @@ jobs:
           git push gitlab T1-F-P --force
 
       - name: generate-breakout-game-from-github-contribution-graph
-        uses: cyprieng/github-breakout@v1.2.3
+        uses: cyprieng/github-breakout@v1.2.4


### PR DESCRIPTION
Bumps 4 Dependabot PRs into one:
- PR #48: cyprieng/github-breakout 1.2.3 → 1.2.4
- PR #49: actions/upload-artifact v5 → v7
- PR #50: microsoft/setup-msbuild v2 → v3
- PR #51: Jimver/cuda-toolkit v0.2.29 → v0.2.35

Closes #48 #49 #50 #51

## Summary by Sourcery

Update GitHub Actions workflows to use newer versions of third-party actions for CUDA setup, MSBuild configuration, artifact upload, and the GitHub breakout game generator.

Build:
- Bump Jimver/cuda-toolkit action from v0.2.29 to v0.2.35 in the build workflow.
- Upgrade microsoft/setup-msbuild action from v2 to v3 in the build workflow.
- Upgrade actions/upload-artifact from v5 to v7 in the build workflow.
- Bump cyprieng/github-breakout action from v1.2.3 to v1.2.4 in the sync-to-gitee-gitlab workflow.