### PR TITLE
feat: loop multi-instance GPU/net/disk schema registration

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -767,7 +767,7 @@ int main(int argc, char* argv[]) {
         addField("memory/available",     FieldType::UInt64, offsetof(SharedMemoryBlock, availableMemory),  8, "B");
         addField("memory/compressed",    FieldType::UInt64, offsetof(SharedMemoryBlock, compressedMemory), 8, "B");
 
-        // --- GPU array (up to 2) ---
+        // --- GPU array ---
         {
             constexpr int maxGpus = sizeof(SharedMemoryBlock::gpus) / sizeof(GPUData);
             char name[64];
@@ -789,10 +789,10 @@ int main(int argc, char* argv[]) {
         }
         addField("gpu/0/temperature", FieldType::Float64, offsetof(SharedMemoryBlock, gpuTemperature), 8, "C");
 
-        // --- Network array (up to 4) ---
+        // --- Network array (capped at 2 to stay within IPC_MAX_FIELDS) ---
         {
-                        constexpr int maxAdapters = 2; // limit to stay under IPC_MAX_FIELDS
-            char name[64];
+            constexpr int maxAdapters = std::min(
+                (int)(sizeof(SharedMemoryBlock::adapters) / sizeof(NetworkAdapterData)), 2);
             for (int i = 0; i < maxAdapters; i++) {
                 size_t base = offsetof(SharedMemoryBlock, adapters) + i * sizeof(NetworkAdapterData);
                 snprintf(name, sizeof(name), "net/%d/name", i);
@@ -808,10 +808,10 @@ int main(int argc, char* argv[]) {
             }
         }
 
-        // --- Disk array (up to 8) ---
+        // --- Disk array (capped at 4 to stay within IPC_MAX_FIELDS) ---
         {
-                        constexpr int maxDisks = 4; // limit to stay under IPC_MAX_FIELDS
-            char name[64];
+            constexpr int maxDisks = std::min(
+                (int)(sizeof(SharedMemoryBlock::disks) / sizeof(SharedMemoryBlock::SharedDiskData)), 4);
             for (int i = 0; i < maxDisks; i++) {
                 size_t base = offsetof(SharedMemoryBlock, disks) + i * sizeof(SharedMemoryBlock::SharedDiskData);
                 snprintf(name, sizeof(name), "disk/%d/letter", i);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -791,7 +791,7 @@ int main(int argc, char* argv[]) {
 
         // --- Network array (capped at 2 to stay within IPC_MAX_FIELDS) ---
         {
-            constexpr int maxAdapters = std::min(
+            constexpr int maxAdapters = (std::min)(
                 (int)(sizeof(SharedMemoryBlock::adapters) / sizeof(NetworkAdapterData)), 2);
             for (int i = 0; i < maxAdapters; i++) {
                 size_t base = offsetof(SharedMemoryBlock, adapters) + i * sizeof(NetworkAdapterData);
@@ -810,7 +810,7 @@ int main(int argc, char* argv[]) {
 
         // --- Disk array (capped at 4 to stay within IPC_MAX_FIELDS) ---
         {
-            constexpr int maxDisks = std::min(
+            constexpr int maxDisks = (std::min)(
                 (int)(sizeof(SharedMemoryBlock::disks) / sizeof(SharedMemoryBlock::SharedDiskData)), 4);
             for (int i = 0; i < maxDisks; i++) {
                 size_t base = offsetof(SharedMemoryBlock, disks) + i * sizeof(SharedMemoryBlock::SharedDiskData);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -767,28 +767,65 @@ int main(int argc, char* argv[]) {
         addField("memory/available",     FieldType::UInt64, offsetof(SharedMemoryBlock, availableMemory),  8, "B");
         addField("memory/compressed",    FieldType::UInt64, offsetof(SharedMemoryBlock, compressedMemory), 8, "B");
 
-        // ─── GPU #0 ───
-        addField("gpu/0/name",        FieldType::String,  offsetof(SharedMemoryBlock, gpus) + offsetof(GPUData, name),      128);
-        addField("gpu/0/brand",       FieldType::String,  offsetof(SharedMemoryBlock, gpus) + offsetof(GPUData, brand),     64);
-        addField("gpu/0/memory",      FieldType::UInt64,  offsetof(SharedMemoryBlock, gpus) + offsetof(GPUData, memory),    8, "B");
-        addField("gpu/0/usage",       FieldType::Float64, offsetof(SharedMemoryBlock, gpus) + offsetof(GPUData, usage),     8, "%", 0, 100);
-        addField("gpu/0/coreFreq",    FieldType::Float64, offsetof(SharedMemoryBlock, gpus) + offsetof(GPUData, coreClock), 8, "MHz");
-        addField("gpu/0/isVirtual",   FieldType::Bool,    offsetof(SharedMemoryBlock, gpus) + offsetof(GPUData, isVirtual), 1);
-        addField("gpu/0/temperature", FieldType::Float64, offsetof(SharedMemoryBlock, gpuTemperature),                      8, "C");
+        // --- GPU array (up to 2) ---
+        {
+            constexpr int maxGpus = sizeof(SharedMemoryBlock::gpus) / sizeof(GPUData);
+            char name[64];
+            for (int i = 0; i < maxGpus; i++) {
+                size_t base = offsetof(SharedMemoryBlock, gpus) + i * sizeof(GPUData);
+                snprintf(name, sizeof(name), "gpu/%d/name", i);
+                addField(name, FieldType::String,  base + offsetof(GPUData, name),     128);
+                snprintf(name, sizeof(name), "gpu/%d/brand", i);
+                addField(name, FieldType::String,  base + offsetof(GPUData, brand),    64);
+                snprintf(name, sizeof(name), "gpu/%d/memory", i);
+                addField(name, FieldType::UInt64,  base + offsetof(GPUData, memory),   8, "B");
+                snprintf(name, sizeof(name), "gpu/%d/usage", i);
+                addField(name, FieldType::Float64, base + offsetof(GPUData, usage),    8, "%", 0, 100);
+                snprintf(name, sizeof(name), "gpu/%d/coreFreq", i);
+                addField(name, FieldType::Float64, base + offsetof(GPUData, coreClock),8, "MHz");
+                snprintf(name, sizeof(name), "gpu/%d/isVirtual", i);
+                addField(name, FieldType::Bool,    base + offsetof(GPUData, isVirtual),1);
+            }
+        }
+        addField("gpu/0/temperature", FieldType::Float64, offsetof(SharedMemoryBlock, gpuTemperature), 8, "C");
 
-        // ─── Network #0 ───
-        addField("net/0/name",  FieldType::String,  offsetof(SharedMemoryBlock, adapters) + offsetof(NetworkAdapterData, name),        128);
-        addField("net/0/mac",   FieldType::String,  offsetof(SharedMemoryBlock, adapters) + offsetof(NetworkAdapterData, mac),         32);
-        addField("net/0/ip",    FieldType::String,  offsetof(SharedMemoryBlock, adapters) + offsetof(NetworkAdapterData, ipAddress),   64);
-        addField("net/0/type",  FieldType::String,  offsetof(SharedMemoryBlock, adapters) + offsetof(NetworkAdapterData, adapterType), 32);
-        addField("net/0/speed", FieldType::UInt64,  offsetof(SharedMemoryBlock, adapters) + offsetof(NetworkAdapterData, speed),       8, "bps");
+        // --- Network array (up to 4) ---
+        {
+                        constexpr int maxAdapters = 2; // limit to stay under IPC_MAX_FIELDS
+            char name[64];
+            for (int i = 0; i < maxAdapters; i++) {
+                size_t base = offsetof(SharedMemoryBlock, adapters) + i * sizeof(NetworkAdapterData);
+                snprintf(name, sizeof(name), "net/%d/name", i);
+                addField(name, FieldType::String,  base + offsetof(NetworkAdapterData, name),        128);
+                snprintf(name, sizeof(name), "net/%d/mac", i);
+                addField(name, FieldType::String,  base + offsetof(NetworkAdapterData, mac),         32);
+                snprintf(name, sizeof(name), "net/%d/ip", i);
+                addField(name, FieldType::String,  base + offsetof(NetworkAdapterData, ipAddress),   64);
+                snprintf(name, sizeof(name), "net/%d/type", i);
+                addField(name, FieldType::String,  base + offsetof(NetworkAdapterData, adapterType), 32);
+                snprintf(name, sizeof(name), "net/%d/speed", i);
+                addField(name, FieldType::UInt64,  base + offsetof(NetworkAdapterData, speed),       8, "bps");
+            }
+        }
 
-        // ─── Disk #0 ───
-        addField("disk/0/letter", FieldType::String,  offsetof(SharedMemoryBlock, disks) + offsetof(SharedMemoryBlock::SharedDiskData, letter),     1);
-        addField("disk/0/label",  FieldType::String,  offsetof(SharedMemoryBlock, disks) + offsetof(SharedMemoryBlock::SharedDiskData, label),      128);
-        addField("disk/0/total",  FieldType::UInt64,  offsetof(SharedMemoryBlock, disks) + offsetof(SharedMemoryBlock::SharedDiskData, totalSize),  8, "B");
-        addField("disk/0/used",   FieldType::UInt64,  offsetof(SharedMemoryBlock, disks) + offsetof(SharedMemoryBlock::SharedDiskData, usedSpace),  8, "B");
-        addField("disk/0/free",   FieldType::UInt64,  offsetof(SharedMemoryBlock, disks) + offsetof(SharedMemoryBlock::SharedDiskData, freeSpace),  8, "B");
+        // --- Disk array (up to 8) ---
+        {
+                        constexpr int maxDisks = 4; // limit to stay under IPC_MAX_FIELDS
+            char name[64];
+            for (int i = 0; i < maxDisks; i++) {
+                size_t base = offsetof(SharedMemoryBlock, disks) + i * sizeof(SharedMemoryBlock::SharedDiskData);
+                snprintf(name, sizeof(name), "disk/%d/letter", i);
+                addField(name, FieldType::String,  base + offsetof(SharedMemoryBlock::SharedDiskData, letter),    1);
+                snprintf(name, sizeof(name), "disk/%d/label", i);
+                addField(name, FieldType::String,  base + offsetof(SharedMemoryBlock::SharedDiskData, label),     128);
+                snprintf(name, sizeof(name), "disk/%d/total", i);
+                addField(name, FieldType::UInt64,  base + offsetof(SharedMemoryBlock::SharedDiskData, totalSize), 8, "B");
+                snprintf(name, sizeof(name), "disk/%d/used", i);
+                addField(name, FieldType::UInt64,  base + offsetof(SharedMemoryBlock::SharedDiskData, usedSpace), 8, "B");
+                snprintf(name, sizeof(name), "disk/%d/free", i);
+                addField(name, FieldType::UInt64,  base + offsetof(SharedMemoryBlock::SharedDiskData, freeSpace), 8, "B");
+            }
+        }
 
         ipcHdr.fieldCount = (uint16_t)ipcFields.size();
         pipeServer.UpdateSchema(ipcHdr, ipcFields);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -793,6 +793,7 @@ int main(int argc, char* argv[]) {
         {
             constexpr int maxAdapters = (std::min)(
                 (int)(sizeof(SharedMemoryBlock::adapters) / sizeof(NetworkAdapterData)), 2);
+            char name[64];
             for (int i = 0; i < maxAdapters; i++) {
                 size_t base = offsetof(SharedMemoryBlock, adapters) + i * sizeof(NetworkAdapterData);
                 snprintf(name, sizeof(name), "net/%d/name", i);
@@ -812,6 +813,7 @@ int main(int argc, char* argv[]) {
         {
             constexpr int maxDisks = (std::min)(
                 (int)(sizeof(SharedMemoryBlock::disks) / sizeof(SharedMemoryBlock::SharedDiskData)), 4);
+            char name[64];
             for (int i = 0; i < maxDisks; i++) {
                 size_t base = offsetof(SharedMemoryBlock, disks) + i * sizeof(SharedMemoryBlock::SharedDiskData);
                 snprintf(name, sizeof(name), "disk/%d/letter", i);


### PR DESCRIPTION
## Summary
Replace hardcoded `gpu/0`, `net/0`, `disk/0` addField calls with loops
registering up to 2 GPUs, 2 network adapters, and 4 disks.

## Changes
- GPU: loop gpu/0~1 (6 fields each + temperature)
- Network: loop net/0~1 (5 fields each)
- Disk: loop disk/0~3 (5 fields each)

## Test plan
- [ ] Windows MSBuild compiles
- [ ] Schema field count within IPC_MAX_FIELDS (64)
- [ ] macOS not affected

## Summary by Sourcery

Enhancements:
- Extend IPC schema to expose up to two GPUs, two network adapters, and four disks using indexed field names.