### PR TITLE
deps: bump Avalonia from 11.2.3 to 12.0.4

### DIFF
--- a/AvaloniaUI/TCMT.Avalonia.csproj
+++ b/AvaloniaUI/TCMT.Avalonia.csproj
@@ -18,11 +18,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.2.3" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="Avalonia" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="12.0.4" Condition="'$(Configuration)' == 'Debug'" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Serilog" Version="4.2.0" />

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Prerequisites: VS 2022 / 2026 with C++/CLI support, CUDA Toolkit 13.2+, .NET 8.0
 ```
 C++ Core (TCMT-M / TCMT.exe)
   │  Collects: CPU, GPU, Memory, Disk, Network, WiFi, Bluetooth, OS, Temperature
-  │  Sources: WMI (Windows), IOKit/sysctl (macOS), LibreHardwareMonitor (Windows .NET),
+  │  Sources: WMI (Windows), IOKit/sysctl (macOS), PawnIO (Windows kernel),
   │           NVML/CUDA (Windows), CoreWLAN/IOBluetooth (macOS), WLAN API (Windows)
   ▼
 IPCDataBlock (macOS) / SharedMemoryBlock (Windows)
@@ -82,12 +82,32 @@ IPCDataBlock (macOS) / SharedMemoryBlock (Windows)
 - `src/DataStruct.h` — Packed `SharedMemoryBlock`. **`WCHAR`** = `char16_t` on macOS, `wchar_t` on Windows. Do NOT change.
 - `AvaloniaUI/Services/IPCServices/` — C# IPC pipeline (IPCPipeClient, IPCMemoryReader, IPCSchema, IPCSystemInfoMapper)
 
+### PawnIO Kernel Driver (Windows-only)
+
+PawnIO is a Windows kernel driver (`namazso/PawnIO.Modules`) that allows user-mode programs
+to execute signed kernel modules for raw hardware access — SMBus, LPC/Super I/O, MSR, and PCI
+config space.
+
+- **Driver**: the PawnIO installer (`PawnIO_setup.exe`) creates `\\.\GLOBALROOT\Device\PawnIO`.
+- **Modules (.bin)**: signed, pre-compiled binaries from the official 0.1.6 release:
+  https://github.com/namazso/PawnIO.Modules/releases/tag/0.1.6
+  (single `release_0_1_6.zip`, extracted into `Resources/PawnIo/*.bin` in the LHM submodule).
+  Our `src/resources.rc` embeds a subset as RCDATA for the PawnIOWrapper.
+- **Wrapper**: `src/core/memory/PawnIOWrapper.h/.cpp` — `CreateFileW` + `DeviceIoControl`.
+- **Consumers**:
+  - `CpuTempReader` — Intel CPU temp via MSR (IA32_THERM_STATUS)
+  - `MemoryTempReader` — DDR5 SPD Hub + LM75 temp via SMBus (I801, PIIX4, NCT6793, Skylake IMC)
+  - `BoardTempReader` — NCT6798D motherboard sensors via LpcIO (Super I/O port I/O)
+- **Detection**: `PawnIOWrapper::IsInstalled()` checks
+  `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\PawnIO` and the device path.
+  All consumers are **opt-in** — if the driver is not installed, they silently return empty results.
+
 ## Platform-Specific Files
 
 Some `.cpp` / `.mm` files are compiled on ONE platform only:
 - `WiFiInfo.mm` — macOS only (CoreWLAN ObjC++). Windows: `WiFiInfo.cpp` + `WiFiInfo_wlan.c`.
 - `BluetoothInfo.mm` — macOS only (IOBluetooth ObjC++). Windows: `BluetoothInfo.cpp`.
-- `TemperatureWrapper.cpp` — Windows only (LibreHardwareMonitor bridge, C++/CLI).
+- `TemperatureWrapper.cpp` — Cross-platform (PawnIO + NVML on Windows, SMC on macOS, sysfs on Linux).
 - `Platform_Windows.cpp` — Windows only.
 - `IOReportSampler.mm` — macOS only (private IOReport.framework + IOKit pmgr, no sudo).
 


### PR DESCRIPTION
Combines dependabot PRs #83, #84, #85 into a single bump:
- **Avalonia** 11.2.3 → 12.0.4
- **Avalonia.Desktop** 11.2.3 → 12.0.4
- **Avalonia.Fonts.Inter** 11.2.3 → 12.0.4
- **Avalonia.Themes.Fluent** 11.2.3 → 12.0.4
- **Avalonia.Diagnostics** 11.2.3 → 12.0.4

Serilog (4.2.0) and CommunityToolkit.Mvvm (8.4.2) already at latest —
#80, #81 already satisfied. DiagnosticsSupport not in current csproj —
#86 skipped.

Supersedes: #83, #84, #85

## Summary by Sourcery

Enhancements:
- Update Avalonia, Avalonia.Desktop, Avalonia.Fonts.Inter, Avalonia.Themes.Fluent, and Avalonia.Diagnostics dependencies from 11.2.3 to 12.0.4.